### PR TITLE
Symlink headers too

### DIFF
--- a/musl-cross.rb
+++ b/musl-cross.rb
@@ -125,6 +125,7 @@ class MuslCross < Formula
     end
 
     bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink Dir["#{libexec}/include/*"]
   end
 
   test do


### PR DESCRIPTION
Symlink Linux headers for easy access to updated version in IDEs configuration
So we don't have to change "/usr/local/Cellar/musl-cross/0.9.7_1/libexec/x86_64-linux-musl/include" after every update

VSCode "c_cpp_properties.json"

        {
            "name": "Linux",
            "includePath": [
                "/usr/local/opt/musl-cross/libexec/include",
                "${workspaceFolder}"
            ],