### PR TITLE
Improve mips support

### DIFF
--- a/musl-cross.rb
+++ b/musl-cross.rb
@@ -127,7 +127,7 @@ class MuslCross < Formula
     system "#{bin}/aarch64-linux-musl-cc", (testpath/"hello.c") if build.with? "aarch64"
     system "#{bin}/arm-linux-musleabihf-cc", (testpath/"hello.c") if build.with? "arm-hf"
     system "#{bin}/arm-linux-musleabi-cc", (testpath/"hello.c") if build.with? "arm"
-    system "${bin}/mips-linux-musl-cc", (testpath/"hello.c") if build.with? "mips"
+    system "#{bin}/mips-linux-musl-cc", (testpath/"hello.c") if build.with? "mips"
   end
 end
 __END__

--- a/musl-cross.rb
+++ b/musl-cross.rb
@@ -16,6 +16,7 @@ class MuslCross < Formula
   option "with-arm", "Build cross-compilers targeting arm-linux-musleabi"
   option "with-i486", "Build cross-compilers targeting i486-linux-musl"
   option "with-mips", "Build cross-compilers targeting mips-linux-musl"
+  option "with-mips64", "Build cross-compilers targeting mips64-linux-musl"
   option "without-x86_64", "Do not build cross-compilers targeting x86_64-linux-musl"
 
   depends_on "gnu-sed" => :build
@@ -76,6 +77,7 @@ class MuslCross < Formula
     targets.push "arm-linux-musleabi" if build.with? "arm"
     targets.push "i486-linux-musl" if build.with? "i486"
     targets.push "mips-linux-musl" if build.with? "mips"
+    targets.push "mips64-linux-musl" if build.with? "mips64"
 
     (buildpath/"resources").mkpath
     resources.each do |resource|
@@ -128,6 +130,7 @@ class MuslCross < Formula
     system "#{bin}/arm-linux-musleabihf-cc", (testpath/"hello.c") if build.with? "arm-hf"
     system "#{bin}/arm-linux-musleabi-cc", (testpath/"hello.c") if build.with? "arm"
     system "#{bin}/mips-linux-musl-cc", (testpath/"hello.c") if build.with? "mips"
+    system "#{bin}/mips64-linux-musl-cc", (testpath/"hello.c") if build.with? "mips64"
   end
 end
 __END__

--- a/musl-cross.rb
+++ b/musl-cross.rb
@@ -16,6 +16,7 @@ class MuslCross < Formula
   option "with-arm", "Build cross-compilers targeting arm-linux-musleabi"
   option "with-i486", "Build cross-compilers targeting i486-linux-musl"
   option "with-mips", "Build cross-compilers targeting mips-linux-musl"
+  option "with-mipsel", "Build cross-compilers targeting mipsel-linux-musl"
   option "with-mips64", "Build cross-compilers targeting mips64-linux-musl"
   option "with-mips64el", "Build cross-compilers targeting mips64el-linux-musl"
   option "without-x86_64", "Do not build cross-compilers targeting x86_64-linux-musl"
@@ -78,6 +79,7 @@ class MuslCross < Formula
     targets.push "arm-linux-musleabi" if build.with? "arm"
     targets.push "i486-linux-musl" if build.with? "i486"
     targets.push "mips-linux-musl" if build.with? "mips"
+    targets.push "mipsel-linux-musl" if build.with? "mipsel"
     targets.push "mips64-linux-musl" if build.with? "mips64"
     targets.push "mips64el-linux-musl" if build.with? "mips64el"
 
@@ -132,6 +134,7 @@ class MuslCross < Formula
     system "#{bin}/arm-linux-musleabihf-cc", (testpath/"hello.c") if build.with? "arm-hf"
     system "#{bin}/arm-linux-musleabi-cc", (testpath/"hello.c") if build.with? "arm"
     system "#{bin}/mips-linux-musl-cc", (testpath/"hello.c") if build.with? "mips"
+    system "#{bin}/mipsel-linux-musl-cc", (testpath/"hello.c") if build.with? "mipsel"
     system "#{bin}/mips64-linux-musl-cc", (testpath/"hello.c") if build.with? "mips64"
     system "#{bin}/mips64el-linux-musl-cc", (testpath/"hello.c") if build.with? "mips64el"
   end

--- a/musl-cross.rb
+++ b/musl-cross.rb
@@ -17,6 +17,7 @@ class MuslCross < Formula
   option "with-i486", "Build cross-compilers targeting i486-linux-musl"
   option "with-mips", "Build cross-compilers targeting mips-linux-musl"
   option "with-mips64", "Build cross-compilers targeting mips64-linux-musl"
+  option "with-mips64el", "Build cross-compilers targeting mips64el-linux-musl"
   option "without-x86_64", "Do not build cross-compilers targeting x86_64-linux-musl"
 
   depends_on "gnu-sed" => :build
@@ -78,6 +79,7 @@ class MuslCross < Formula
     targets.push "i486-linux-musl" if build.with? "i486"
     targets.push "mips-linux-musl" if build.with? "mips"
     targets.push "mips64-linux-musl" if build.with? "mips64"
+    targets.push "mips64el-linux-musl" if build.with? "mips64el"
 
     (buildpath/"resources").mkpath
     resources.each do |resource|
@@ -131,6 +133,7 @@ class MuslCross < Formula
     system "#{bin}/arm-linux-musleabi-cc", (testpath/"hello.c") if build.with? "arm"
     system "#{bin}/mips-linux-musl-cc", (testpath/"hello.c") if build.with? "mips"
     system "#{bin}/mips64-linux-musl-cc", (testpath/"hello.c") if build.with? "mips64"
+    system "#{bin}/mips64el-linux-musl-cc", (testpath/"hello.c") if build.with? "mips64el"
   end
 end
 __END__


### PR DESCRIPTION
Adds support for the following mips targets:
- mipsel-linux-musl
- mips64-linux-musl
- mips64el-linux-musl

Also fixes an issue with variable substitution in the test for the existing mips target.